### PR TITLE
Make i3batwarn.sh not print itself when run

### DIFF
--- a/i3batwarn.sh
+++ b/i3batwarn.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 #############################################
 # This is a simple battery warning script.  #


### PR DESCRIPTION
Since this script is meant to be run every-so-often by cron or so, I think it is wholly unnecessary having it print itself every time its run. I noticed it because my logs (`journalctl`) were clogged up.